### PR TITLE
Add support for fallback APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ Here are the available configuration options:
 - `server.port`: The port on which the server runs. Default is `3000`
 - `server.baseUrl`: The base url port on which the server is accessible. Default is `http://localhost:3000`
 - `esplora.baseUrl`: The base URL of the Esplora API instance to connect to. Default is `https://blockstream.info`
+- `esplora.fallbacekBaseUrl`: The base URL of the Esplora API instance to fallback to if the primary instance is unavailable.
 - `mempool.baseUrl`: The base URL of the Mempool instance to connect to. Default is `https://mempool.space`
+- `mempool.fallbacekBaseUrl`: The base URL of the Mempool instance to fallback to if the primary instance is unavailable.
 - `mempool.depth`: The number of blocks to use for mempool-based fee estimates. Default is `6`. Valid options are `1`, `3`, and `6`
 - `settings.feeMultiplier`: The multiplier to apply to the fee estimates. Default is `1` (a conservative approach to ensure that the fee estimates are always slightly higher than the raw estimates)
 - `cache.stdTTL`: The standard time to live in seconds for every generated cache element. Default is `15`
@@ -80,7 +82,9 @@ In addition to configuring the application through the config files, you can als
 - `PORT`: Overrides `server.port`
 - `BASE_URL`: Overrides `server.baseUrl`
 - `ESPLORA_BASE_URL`: Overrides `esplora.baseUrl`
+- `ESPLORA_FALLBACK_BASE_URL`: Overrides `esplora.fallbackBaseUrl`
 - `MEMPOOL_BASE_URL`: Overrides `mempool.baseUrl`
+- `MEMPOOL_FALLBACK_BASE_URL`: Overrides `mempool.fallbackBaseUrl`
 - `MEMPOOL_DEPTH`: Overrides `mempool.depth`
 - `FEE_MULTIPLIER`: Overrides `settings.feeMultiplier`
 - `CACHE_STDTTL`: Overrides `cache.stdTTL`

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -8,10 +8,12 @@
     },
     "mempool": {
         "baseUrl": "MEMPOOL_BASE_URL",
+        "fallbackBaseUrl": "MEMPOOL_FALLBACK_BASE_URL",
         "depth": "MEMPOOL_DEPTH"
     },
     "esplora": {
-        "baseUrl": "ESPLORA_BASE_URL"
+        "baseUrl": "ESPLORA_BASE_URL",
+        "fallbackBaseUrl": "ESPLORA_FALLBACK_BASE_URL"
     },
     "cache": {
         "stdTTL": "CACHE_STD_TTL",

--- a/config/default.json
+++ b/config/default.json
@@ -8,10 +8,12 @@
     },
     "mempool": {
         "baseUrl": "https://mempool.space",
+        "fallbackBaseUrl": null,
         "depth": 6
     },
     "esplora": {
-        "baseUrl": "https://blockstream.info"
+        "baseUrl": "https://blockstream.info",
+        "fallbackBaseUrl": null
     },
     "cache": {
         "stdTTL": 15,

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -29,3 +29,5 @@ interface SiteData {
   subtitle: string,
   children?: any
 }
+
+type ExpectedResponseType = 'json' | 'text';


### PR DESCRIPTION
Add support for fallback APIs for both Mempool and Esplora. Provides improved redundancy in the event that the primary APIs are down.