### PR TITLE
Provide current block height data

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -16,6 +16,7 @@ type FeeByBlockTarget = {
 // Estimates represents the current block hash and fee by block target.
 type Estimates = {
   current_block_hash: string | null; // current block hash
+  current_block_height: number | null; // current block height
   fee_by_block_target: FeeByBlockTarget; // fee by block target (in sat/kb)
 };
 


### PR DESCRIPTION
This pull request primarily focuses on adding functionality to fetch and handle the current block height in the `src/util.ts` file. The changes include adding new URLs for fetching the block height, a new function to fetch the block height, and updating the `getEstimates()` function to include the fetched block height.

URL additions:

* [`src/util.ts`](diffhunk://#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1L38-R68): Added primary and fallback URLs for fetching the current block height from the Mempool and Esplora APIs.

New function:

* [`src/util.ts`](diffhunk://#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1R355-R381): Added the `fetchBlocksTipHeight()` function, which asynchronously fetches the current block height from the Mempool and Esplora APIs.

Function update:

* [`src/util.ts`](diffhunk://#diff-3294a832ea2276e554177e0b3007cc2d401c082912c7fbde49fa09141bf1aed1R398-R413): Updated the `getEstimates()` function to fetch the current block height and include it in the returned estimates object.