### PR TITLE
Add maxHeightDelta setting to exclude stale data

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,16 +68,17 @@ Here are the available configuration options:
 
 ### Application settings
 
-| Config Key               | Description                                                                                               | Default Value           | Environment Variable |
-| ------------------------ | --------------------------------------------------------------------------------------------------------- | ----------------------- | -------------------- |
-| `server.port`            | The port on which the server runs                                                                         | `3000`                  | `PORT`               |
-| `server.baseUrl`         | The base url port on which the server is accessible                                                       | `http://localhost:3000` | `BASE_URL`           |
-| `settings.logLevel`      | The log level to use for the application                                                                  | `debug`                 | `LOGLEVEL`           |
-| `settings.timeout`       | Timeout to use when fetching data (ms)                                                                    | `5000`                  | `TIMEOUT`            |
-| `settings.feeMultiplier` | The multiplier to apply to the fee estimates                                                              | `1`                     | `FEE_MULTIPLIER`     |
-| `settings.feeMinimum`    | The minimum fee (sat/vB) to use for fee estimates if we could not determine from a configured data source | `2`                     | `FEE_MINIMUM`        |
-| `cache.stdTTL`           | The standard time to live in seconds for every generated cache element                                    | `15`                    | `CACHE_STDTTL`       |
-| `cache.checkperiod`      | The period in seconds, used for the automatic delete check interval                                       | `20`                    | `CACHE_CHECKPERIOD`  |
+| Config Key                | Description                                                                                               | Default Value           | Environment Variable |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------- | -------------------- |
+| `server.port`             | The port on which the server runs                                                                         | `3000`                  | `PORT`               |
+| `server.baseUrl`          | The base url port on which the server is accessible                                                       | `http://localhost:3000` | `BASE_URL`           |
+| `settings.logLevel`       | The log level to use for the application                                                                  | `debug`                 | `LOGLEVEL`           |
+| `settings.timeout`        | Timeout to use when fetching data (ms)                                                                    | `5000`                  | `TIMEOUT`            |
+| `settings.feeMultiplier`  | The multiplier to apply to the fee estimates                                                              | `1`                     | `FEE_MULTIPLIER`     |
+| `settings.feeMinimum`     | The minimum fee (sat/vB) to use for fee estimates if we could not determine from a configured data source | `2`                     | `FEE_MINIMUM`        |
+| `settings.maxHeightDelta` | The maximum acceptable difference between the block heights of the most current fee estimates.            | `3`                     | `MAX_HEIGHT_DELTA`   |
+| `cache.stdTTL`            | The standard time to live in seconds for every generated cache element                                    | `15`                    | `CACHE_STDTTL`       |
+| `cache.checkperiod`       | The period in seconds, used for the automatic delete check interval                                       | `20`                    | `CACHE_CHECKPERIOD`  |
 
 ### Mempool settings
 

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -7,7 +7,8 @@
     "loglevel": "LOGLEVEL",
     "timeout": "TIMEOUT",
     "feeMultiplier": "FEE_MULTIPLIER",
-    "feeMinimum": "FEE_MINIMUM"
+    "feeMinimum": "FEE_MINIMUM",
+    "maxHeightDelta": "MAX_HEIGHT_DELTA"
   },
   "mempool": {
     "baseUrl": "MEMPOOL_BASE_URL",

--- a/config/default.json
+++ b/config/default.json
@@ -7,7 +7,8 @@
     "loglevel": "debug",
     "timeout": 5000,
     "feeMultiplier": 1,
-    "feeMinimum": 2
+    "feeMinimum": 2,
+    "maxHeightDelta": 3
   },
   "mempool": {
     "baseUrl": "https://mempool.space",

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -35,6 +35,7 @@ const LOGLEVEL = config.get<string>("settings.loglevel");
 const TIMEOUT = config.get<number>("settings.timeout");
 const FEE_MULTIPLIER = config.get<number>("settings.feeMultiplier");
 const FEE_MINIMUM = config.get<number>("settings.feeMinimum");
+const MAX_HEIGHT_DELTA = config.get<number>("settings.maxHeightDelta");
 const CACHE_STDTTL = config.get<number>("cache.stdTTL");
 const CACHE_CHECKPERIOD = config.get<number>("cache.checkperiod");
 
@@ -49,6 +50,7 @@ const service = new DataProviderManager(
     stdTTL: CACHE_STDTTL,
     checkperiod: CACHE_CHECKPERIOD,
   },
+  MAX_HEIGHT_DELTA,
   FEE_MULTIPLIER,
   FEE_MINIMUM,
 );

--- a/test/DataProviderManager.test.ts
+++ b/test/DataProviderManager.test.ts
@@ -76,6 +76,5 @@ test("should merge fee estimates from multiple providers correctly", async () =>
     "2": 20000,
     "3": 5000,
     "5": 3000,
-    "10": 1000,
   });
 });


### PR DESCRIPTION
This pull request introduces a new configuration option `maxHeightDelta` to the application, which represents the maximum acceptable difference between the block heights of the most current fee estimates. The `maxHeightDelta` is added to the `DataProviderManager` class and is used to filter out data points that don't meet the relevancy threshold criteria. The changes also include the necessary updates to the configuration files and the server setup.

Here are the most significant changes:

Configuration updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R79): Added a new configuration option `settings.maxHeightDelta` to the list of available configuration options.
* [`config/custom-environment-variables.json`](diffhunk://#diff-822cad868abefc13eb54d59cc2aedb564b3dd0fab6ca48047e2dbbb13ddb2875L10-R11): Included the `maxHeightDelta` in the environment variable mapping.
* [`config/default.json`](diffhunk://#diff-f07c42814e0913799fda32ac14d063f1ef8a04e24fb6febd873a5f161e58a8d4L10-R11): Added a default value for `maxHeightDelta`.

Codebase changes:
* [`src/lib/DataProviderManager.ts`](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4R10-R22): Added `maxHeightDelta` as a member of the `DataProviderManager` class. Replaced the `getSortedDataPoints` method with `getRelevantDataPoints` that filters out data points based on the `maxHeightDelta`. [[1]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4R10-R22) [[2]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L46-R49) [[3]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4R126-R149)
* [`src/server.tsx`](diffhunk://#diff-6753353f379b5a26bc9c1219ea6030e27ff3ab93d2f13576f053a426bbe8c05fR38): Retrieved `maxHeightDelta` from the configuration and passed it to the `DataProviderManager` constructor. [[1]](diffhunk://#diff-6753353f379b5a26bc9c1219ea6030e27ff3ab93d2f13576f053a426bbe8c05fR38) [[2]](diffhunk://#diff-6753353f379b5a26bc9c1219ea6030e27ff3ab93d2f13576f053a426bbe8c05fR53)

Test updates:
* [`test/DataProviderManager.test.ts`](diffhunk://#diff-482cbd209ab3e7cf1ba2ed4f9d0b7452aef3ea41e72ee3710eca59174d6fb5e8L79): Updated the test case to match the new behavior.