### PR TITLE
Ensure mempool estimates take precedence

### DIFF
--- a/src/providers/esplora.ts
+++ b/src/providers/esplora.ts
@@ -1,4 +1,4 @@
-import { fetchData, LOGLEVEL } from "../lib/util";
+import { fetchData, LOGLEVEL, TIMEOUT } from "../lib/util";
 import { logger } from "../lib/logger";
 
 const log = logger(LOGLEVEL);
@@ -14,7 +14,7 @@ const log = logger(LOGLEVEL);
  * methods and properties for a data provider.
  *
  * @example
- * const provider = new EsploraProvider('https://blockstream.info/api/');
+ * const provider = new EsploraProvider('https://blockstream.info');
  * const data = await provider.getAllData();
  */
 export class EsploraProvider implements Provider {
@@ -32,7 +32,7 @@ export class EsploraProvider implements Provider {
   constructor(
     url: string,
     defaultDepth: number,
-    defaultTimeout: number = 5000,
+    defaultTimeout: number = TIMEOUT,
   ) {
     this.url = url;
     this.depth = defaultDepth;

--- a/src/providers/mempool.ts
+++ b/src/providers/mempool.ts
@@ -1,4 +1,4 @@
-import { fetchData, LOGLEVEL } from "../lib/util";
+import { fetchData, LOGLEVEL, TIMEOUT } from "../lib/util";
 import { logger } from "../lib/logger";
 
 const log = logger(LOGLEVEL);
@@ -29,7 +29,7 @@ export class MempoolProvider implements Provider {
   constructor(
     url: string,
     defaultDepth: number,
-    defaultTimeout: number = 5000,
+    defaultTimeout: number = TIMEOUT,
   ) {
     this.url = url;
     this.depth = defaultDepth;

--- a/test/DataProviderManager.test.ts
+++ b/test/DataProviderManager.test.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "bun:test";
 import { DataProviderManager } from "../src/lib/DataProviderManager";
+import { MempoolProvider } from "../src/providers/mempool";
+import { EsploraProvider } from "../src/providers/esplora";
 
 class MockProvider1 implements Provider {
   getBlockHeight = () => Promise.resolve(998);
@@ -77,4 +79,48 @@ test("should merge fee estimates from multiple providers correctly", async () =>
     "3": 5000,
     "5": 3000,
   });
+});
+
+test("sorts providers correctly", async () => {
+  const mempoolProvider = new MempoolProvider("https://mempool.space", 6);
+  const esploraProvider = new EsploraProvider("https://blockstream.info", 6);
+
+  // Register the providers in the correct order
+  const manager = new DataProviderManager();
+  manager.registerProvider(mempoolProvider);
+  manager.registerProvider(esploraProvider);
+  const dataPoints = await manager.getSortedDataPoints();
+  expect(dataPoints[0].provider).toBe(mempoolProvider);
+  expect(dataPoints[1].provider).toBe(esploraProvider);
+
+  // Register the providers in reverse order
+  const manager2 = new DataProviderManager();
+  manager2.registerProvider(esploraProvider);
+  manager2.registerProvider(mempoolProvider);
+  const dataPoints2 = await manager.getSortedDataPoints();
+  expect(dataPoints2[0].provider).toBe(mempoolProvider);
+  expect(dataPoints2[1].provider).toBe(esploraProvider);
+
+  // Register multiple mempool providers with different block heights
+  class mempool1 extends MempoolProvider {
+    getBlockHeight = () => Promise.resolve(999);
+    getBlockHash = () => Promise.resolve("hash1");
+    getFeeEstimates = () => Promise.resolve({});
+  }
+  class mempool2 extends MempoolProvider {
+    getBlockHeight = () => Promise.resolve(1000);
+    getBlockHash = () => Promise.resolve("hash1");
+    getFeeEstimates = () => Promise.resolve({});
+  }
+  class mempool3 extends MempoolProvider {
+    getBlockHeight = () => Promise.resolve(999);
+    getBlockHash = () => Promise.resolve("hash1");
+    getFeeEstimates = () => Promise.resolve({});
+  }
+  const manager3 = new DataProviderManager();
+  manager3.registerProvider(new mempool1("https://mempool.space", 6));
+  manager3.registerProvider(new mempool2("https://mempool.space", 6));
+  manager3.registerProvider(new mempool3("https://mempool.space", 6));
+  const dataPoints3 = await manager3.getSortedDataPoints();
+  expect(dataPoints3[0].blockHeight).toBe(1000);
 });


### PR DESCRIPTION
This pull request introduces several changes in the `DataProviderManager.ts`, `esplora.ts`, `mempool.ts`, and `DataProviderManager.test.ts` files. The key modifications include the addition of a new `MempoolProvider` import, changes to the `DataProviderManager` class constructor, and modifications to the `getSortedDataPoints` method. Additionally, the `EsploraProvider` and `MempoolProvider` class constructors were updated to use a new `TIMEOUT` constant imported from `util`. Lastly, a new test case was added to `DataProviderManager.test.ts` to ensure that providers are sorted correctly.

Changes to `DataProviderManager.ts`:
* Imported `MempoolProvider` from `../providers/mempool`.
* Updated the `DataProviderManager` class constructor to provide default values for `cacheConfig`.
* Modified the `getSortedDataPoints` method to prioritize mempool-based estimates and made it public.

Changes to `esplora.ts` and `mempool.ts`:
* Imported `TIMEOUT` from `../lib/util` and used it as the default value for `defaultTimeout` in the `EsploraProvider` and `MempoolProvider` class constructors [[1]](diffhunk://#diff-a2bc951c0d20eca10a6d0818f85fe3d4ae3b63e51fbba3a195148553470fcf6bL1-R1) [[2]](diffhunk://#diff-a2bc951c0d20eca10a6d0818f85fe3d4ae3b63e51fbba3a195148553470fcf6bL35-R35) [[3]](diffhunk://#diff-1fd5ab7ccc4c8b3fc8bd68e64c8437bb611567aa9f0842463420da0529420539L1-R1) [[4]](diffhunk://#diff-1fd5ab7ccc4c8b3fc8bd68e64c8437bb611567aa9f0842463420da0529420539L32-R32).
* Updated the example URL in the `EsploraProvider` class documentation.

Changes to `DataProviderManager.test.ts`:
* Imported `MempoolProvider` and `EsploraProvider` from their respective modules.
* Added a new test case to ensure that providers are sorted correctly.