### PR TITLE
Register bitcoind provider before esplora

### DIFF
--- a/src/server.tsx
+++ b/src/server.tsx
@@ -66,16 +66,6 @@ MEMPOOL_FALLBACK_BASE_URL &&
     new MempoolProvider(MEMPOOL_FALLBACK_BASE_URL, MEMPOOL_DEPTH, TIMEOUT),
   );
 
-ESPLORA_BASE_URL &&
-  service.registerProvider(
-    new EsploraProvider(ESPLORA_BASE_URL, 1008, TIMEOUT),
-  );
-
-ESPLORA_FALLBACK_BASE_URL &&
-  service.registerProvider(
-    new EsploraProvider(ESPLORA_FALLBACK_BASE_URL, 1008, TIMEOUT),
-  );
-
 BITCOIND_BASE_URL &&
   service.registerProvider(
     new BitcoindProvider(
@@ -85,6 +75,16 @@ BITCOIND_BASE_URL &&
       BITCOIND_CONF_TARGETS,
       BITCOIND_ESTIMATE_MODE,
     ),
+  );
+
+ESPLORA_BASE_URL &&
+  service.registerProvider(
+    new EsploraProvider(ESPLORA_BASE_URL, 1008, TIMEOUT),
+  );
+
+ESPLORA_FALLBACK_BASE_URL &&
+  service.registerProvider(
+    new EsploraProvider(ESPLORA_FALLBACK_BASE_URL, 1008, TIMEOUT),
   );
 
 // Define the app.


### PR DESCRIPTION
This pull request primarily involves modifications to the `src/server.tsx` file. The changes reorganize the order in which service providers are registered. Specifically, the `EsploraProvider` instances are now registered after the `BitcoindProvider` instance.

Here are the key changes:

* [`src/server.tsx`](diffhunk://#diff-6753353f379b5a26bc9c1219ea6030e27ff3ab93d2f13576f053a426bbe8c05fL69-L78): The registration of `EsploraProvider` instances with `ESPLORA_BASE_URL` and `ESPLORA_FALLBACK_BASE_URL` has been moved after the registration of the `BitcoindProvider` instance with `BITCOIND_BASE_URL`. This change affects the order in which these service providers are registered. [[1]](diffhunk://#diff-6753353f379b5a26bc9c1219ea6030e27ff3ab93d2f13576f053a426bbe8c05fL69-L78) [[2]](diffhunk://#diff-6753353f379b5a26bc9c1219ea6030e27ff3ab93d2f13576f053a426bbe8c05fR80-R89)