### PR TITLE
Ensure all estimates below feeMinimum are excluded

### DIFF
--- a/test/DataProviderManager-merge.test.ts
+++ b/test/DataProviderManager-merge.test.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "bun:test";
+import { DataProviderManager } from "../src/lib/DataProviderManager";
+
+class MockProvider0 implements Provider {
+  getBlockHeight = () => Promise.resolve(1001);
+  getBlockHash = () => Promise.resolve("hash1001");
+  getFeeEstimates = () =>
+    Promise.resolve({
+      "1": 1,
+      "2": 1,
+      "3": 1,
+    });
+  getAllData = () =>
+    Promise.resolve({
+      blockHeight: 1001,
+      blockHash: "hash1001",
+      feeEstimates: {
+        "1": 1,
+        "2": 1,
+        "3": 1,
+      },
+    });
+}
+
+class MockProvider1 implements Provider {
+  getBlockHeight = () => Promise.resolve(998);
+  getBlockHash = () => Promise.resolve("hash998");
+  getFeeEstimates = () =>
+    Promise.resolve({
+      "1": 20,
+      "10": 1,
+    });
+  getAllData = () =>
+    Promise.resolve({
+      blockHeight: 998,
+      blockHash: "hash998",
+      feeEstimates: {
+        "1": 20,
+        "10": 1,
+      },
+    });
+}
+
+class MockProvider2 implements Provider {
+  getBlockHeight = () => Promise.resolve(1000);
+  getBlockHash = () => Promise.resolve("hash1000");
+  getFeeEstimates = () =>
+    Promise.resolve({
+      "1": 30,
+      "2": 20,
+    });
+  getAllData = () =>
+    Promise.resolve({
+      blockHeight: 1000,
+      blockHash: "hash1000",
+      feeEstimates: {
+        "1": 30,
+        "2": 20,
+      },
+    });
+}
+
+class MockProvider3 implements Provider {
+  getBlockHeight = () => Promise.resolve(999);
+  getBlockHash = () => Promise.resolve("hash999");
+  getFeeEstimates = () =>
+    Promise.resolve({
+      "1": 25,
+      "2": 15,
+      "3": 5,
+      "5": 3,
+    });
+  getAllData = () =>
+    Promise.resolve({
+      blockHeight: 999,
+      blockHash: "hash999",
+      feeEstimates: {
+        "1": 25,
+        "2": 15,
+        "3": 5,
+        "5": 3,
+      },
+    });
+}
+
+const maxHeightDelta = 2;
+const feeMultiplier = 2;
+const feeMinimum = 2;
+const manager = new DataProviderManager({ stdTTL: 0, checkperiod: 0 }, maxHeightDelta, feeMultiplier, feeMinimum);
+manager.registerProvider(new MockProvider0());
+manager.registerProvider(new MockProvider1());
+manager.registerProvider(new MockProvider2());
+manager.registerProvider(new MockProvider3());
+
+test("should merge fee estimates from multiple providers correctly", async () => {
+  const mergedData = await manager.getData();
+  expect(mergedData.current_block_height).toEqual(1001);
+  expect(mergedData.current_block_hash).toEqual("hash1001");
+  expect(mergedData.fee_by_block_target).toEqual({
+    "1": 60000,
+    "2": 40000,
+    "3": 10000,
+    "5": 6000,
+  });
+});

--- a/test/DataProviderManager-sort.test.ts
+++ b/test/DataProviderManager-sort.test.ts
@@ -6,80 +6,43 @@ import { EsploraProvider } from "../src/providers/esplora";
 class MockProvider1 implements Provider {
   getBlockHeight = () => Promise.resolve(998);
   getBlockHash = () => Promise.resolve("hash1");
-  getFeeEstimates = () =>
-    Promise.resolve({
-      "1": 20,
-      "10": 1,
-    });
+  getFeeEstimates = () => Promise.resolve({});
   getAllData = () =>
     Promise.resolve({
       blockHeight: 998,
       blockHash: "hash1",
-      feeEstimates: {
-        "1": 20,
-        "10": 1,
-      },
+      feeEstimates: {},
     });
 }
 
 class MockProvider2 implements Provider {
   getBlockHeight = () => Promise.resolve(1000);
   getBlockHash = () => Promise.resolve("hash3");
-  getFeeEstimates = () =>
-    Promise.resolve({
-      "1": 30,
-      "2": 20,
-    });
+  getFeeEstimates = () => Promise.resolve({});
   getAllData = () =>
     Promise.resolve({
       blockHeight: 1000,
       blockHash: "hash3",
-      feeEstimates: {
-        "1": 30,
-        "2": 20,
-      },
+      feeEstimates: {},
     });
 }
 
 class MockProvider3 implements Provider {
   getBlockHeight = () => Promise.resolve(999);
   getBlockHash = () => Promise.resolve("hash2");
-  getFeeEstimates = () =>
-    Promise.resolve({
-      "1": 25,
-      "2": 15,
-      "3": 5,
-      "5": 3,
-    });
+  getFeeEstimates = () => Promise.resolve({});
   getAllData = () =>
-    Promise.resolve({
+    Promise.resolve(({
       blockHeight: 999,
       blockHash: "hash2",
-      feeEstimates: {
-        "1": 25,
-        "2": 15,
-        "3": 5,
-        "5": 3,
-      },
-    });
+      feeEstimates: {},
+    }));
 }
 
 const manager = new DataProviderManager({ stdTTL: 0, checkperiod: 0 });
 manager.registerProvider(new MockProvider1());
 manager.registerProvider(new MockProvider2());
 manager.registerProvider(new MockProvider3());
-
-test("should merge fee estimates from multiple providers correctly", async () => {
-  const mergedData = await manager.getData();
-  expect(mergedData.current_block_height).toEqual(1000);
-  expect(mergedData.current_block_hash).toEqual("hash3");
-  expect(mergedData.fee_by_block_target).toEqual({
-    "1": 30000,
-    "2": 20000,
-    "3": 5000,
-    "5": 3000,
-  });
-});
 
 test("sorts providers correctly", async () => {
   const mempoolProvider = new MempoolProvider("https://mempool.space", 6);


### PR DESCRIPTION
This PR addresses an issue in which invalid estimates (estimates below the configured fee minimum) were treated as valid if they came from the determined most relevant data providers (provider with the highest block height). In reality, even the provider with the highest block height can include invalid estimates that need to be filtered out.

This pull request introduces changes to the `DataProviderManager` class in the `src/lib/DataProviderManager.ts` file and its associated tests. The changes mainly involve the refactoring of how fee estimates are handled, with the introduction of a new method to filter fee estimates, and changes to the merging of fee estimates. The tests have also been updated to reflect these changes.

Refactoring of fee estimates handling:

* [`src/lib/DataProviderManager.ts`](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L55-L65): The comment in the fee calculation section was updated to reflect the new fee formatting approach. The conditional logic for applying the fee multiplier was removed, and the warning log for estimates below the minimum fee was also removed. A new private method `filterEstimates` was introduced to handle the filtering of fee estimates based on the fee minimum. This method also logs a warning for estimates below the minimum fee. [[1]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L55-L65) [[2]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4R160-R194)

Changes to merging of fee estimates:

* [`src/lib/DataProviderManager.ts`](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4R160-R194): The `mergeFeeEstimates` method was modified to initialize `mergedEstimates` as an empty object and to use the new `filterEstimates` method when iterating over data points. The condition for adding an estimate to `mergedEstimates` was also updated to account for cases where an estimate for a block target does not yet exist in `mergedEstimates`. [[1]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4R160-R194) [[2]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L188-R205)

Updates to tests:

* [`test/DataProviderManager-merge.test.ts`](diffhunk://#diff-4c6bb31fe4a46222f4a3279b384d38e362f0abce4b247fbbfe7eb97ff84eb3cbR1-R105): A new test file was added to specifically test the merging of fee estimates from multiple providers. Mock providers were created and registered to a `DataProviderManager` instance, and a test was added to check that the fee estimates are merged correctly.

* [`test/DataProviderManager-sort.test.ts`](diffhunk://#diff-ef67a0d36617d507a11f7c53fe6c11d96fb19450f0d00672915394cafa74504dL9-L83): This file was renamed from `test/DataProviderManager.test.ts`. The mock providers in this file were updated to return empty fee estimates, and the test for merging fee estimates was removed.