### PR TITLE
Filter out duplicate estimates

### DIFF
--- a/src/lib/DataProviderManager.ts
+++ b/src/lib/DataProviderManager.ts
@@ -196,12 +196,10 @@ export class DataProviderManager {
       log.debug({ msg: `Estimates for dataPoint ${providerName}`, estimates });
 
       keys.forEach((key) => {
-        // Only add the estimate if it has a higher confirmation target and a lower fee
+        // Only add the estimate if it has a higher confirmation target and a lower fee.
         if (
-          (!mergedEstimates[key] && estimates[key]) ||
-          (mergedEstimates[key] &&
-            key > Math.max(...Object.keys(mergedEstimates).map(Number)) &&
-            estimates[key] < Math.min(...Object.values(mergedEstimates)))
+          key > Math.max(...Object.keys(mergedEstimates).map(Number)) &&
+          estimates[key] < Math.min(...Object.values(mergedEstimates))
         ) {
           log.debug({
             msg: `Adding estimate from ${providerName} with target ${key} and fee ${estimates[key]} to mergedEstimates`,

--- a/test/DataProviderManager-merge.test.ts
+++ b/test/DataProviderManager-merge.test.ts
@@ -69,6 +69,8 @@ class MockProvider3 implements Provider {
       "2": 15,
       "3": 5,
       "5": 3,
+      "6": 3,
+      "7": 3,
     });
   getAllData = () =>
     Promise.resolve({
@@ -79,6 +81,8 @@ class MockProvider3 implements Provider {
         "2": 15,
         "3": 5,
         "5": 3,
+        "6": 3,
+        "7": 3,
       },
     });
 }


### PR DESCRIPTION
This addresses a bug in which duplicate entries were not always filtered out.

This pull request involves changes to the `DataProviderManager` class in `src/lib/DataProviderManager.ts` and the `MockProvider3` class in `test/DataProviderManager-merge.test.ts`. The changes primarily aim to refine the logic for adding estimates and expand the test data for the `MockProvider3` class.

Here are the key changes:

Changes to `DataProviderManager` class:

* [`src/lib/DataProviderManager.ts`](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L199-R202): The logic for adding estimates has been simplified. The condition for adding an estimate now only checks if the current estimate is lower than the minimum of all existing estimates. The check for the absence of `mergedEstimates[key]` and the presence of `estimates[key]` has been removed. This change streamlines the logic and potentially improves the efficiency of the function.

Changes to `MockProvider3` class:

* [`test/DataProviderManager-merge.test.ts`](diffhunk://#diff-4c6bb31fe4a46222f4a3279b384d38e362f0abce4b247fbbfe7eb97ff84eb3cbR72-R73): Additional test data has been added to the `MockProvider3` class. Specifically, data points with keys "6" and "7" have been added to the `getAllData` method. This expanded test data can provide a more comprehensive evaluation of the `DataProviderManager`'s functionality. [[1]](diffhunk://#diff-4c6bb31fe4a46222f4a3279b384d38e362f0abce4b247fbbfe7eb97ff84eb3cbR72-R73) [[2]](diffhunk://#diff-4c6bb31fe4a46222f4a3279b384d38e362f0abce4b247fbbfe7eb97ff84eb3cbR84-R85)