### PR TITLE
Ensure that fee minimum estimate is returned when no estimates

### DIFF
--- a/src/lib/DataProviderManager.ts
+++ b/src/lib/DataProviderManager.ts
@@ -59,6 +59,11 @@ export class DataProviderManager {
       );
     }
 
+    // If we don't have any estimates that are above the fee minimum, add a single estimate at the fee minimum.
+    if (Object.keys(feeEstimates).length === 0) {
+      feeEstimates["1"] = this.feeMinimum * 1000;
+    }
+
     data = {
       current_block_height: blockHeight,
       current_block_hash: blockHash,

--- a/test/DataProviderManager-minfee.test.ts
+++ b/test/DataProviderManager-minfee.test.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "bun:test";
+import { DataProviderManager } from "../src/lib/DataProviderManager";
+
+test("should exclude estimates that are below the fee minimum", async () => {
+  const feeEstimates = {
+    "1": 3,
+    "2": 2,
+    "3": 1,
+  };
+  class MockProvider implements Provider {
+    getBlockHeight = () => Promise.resolve(1001);
+    getBlockHash = () => Promise.resolve("hash1001");
+    getFeeEstimates = () => Promise.resolve(feeEstimates);
+    getAllData = () =>
+      Promise.resolve({
+        blockHeight: 1001,
+        blockHash: "hash1001",
+        feeEstimates,
+      });
+  }
+
+  const maxHeightDelta = 1;
+  const feeMultiplier = 1;
+  const feeMinimum = 2;
+  const manager = new DataProviderManager(
+    { stdTTL: 0, checkperiod: 0 },
+    maxHeightDelta,
+    feeMultiplier,
+    feeMinimum,
+  );
+  manager.registerProvider(new MockProvider());
+
+  const mergedData = await manager.getData();
+  expect(mergedData.fee_by_block_target).toEqual({
+    "1": 3000,
+    "2": 2000,
+  });
+});
+
+test("should return single estimate at fee minimum if no valid estimates are available", async () => {
+  const feeEstimates = {
+    "1": 1,
+    "2": 1,
+    "3": 1,
+  };
+  class MockProvider implements Provider {
+    getBlockHeight = () => Promise.resolve(1001);
+    getBlockHash = () => Promise.resolve("hash1001");
+    getFeeEstimates = () => Promise.resolve(feeEstimates);
+    getAllData = () =>
+      Promise.resolve({
+        blockHeight: 1001,
+        blockHash: "hash1001",
+        feeEstimates,
+      });
+  }
+
+  const maxHeightDelta = 1;
+  const feeMultiplier = 1;
+  const feeMinimum = 2;
+  const manager = new DataProviderManager(
+    { stdTTL: 0, checkperiod: 0 },
+    maxHeightDelta,
+    feeMultiplier,
+    feeMinimum,
+  );
+  manager.registerProvider(new MockProvider());
+
+  const mergedData = await manager.getData();
+  expect(mergedData.fee_by_block_target).toEqual({
+    "1": 2000,
+  });
+});


### PR DESCRIPTION
This pull request primarily introduces a new feature to the `DataProviderManager` class and adds corresponding tests. The main change is the addition of a condition to handle cases when there are no fee estimates above the fee minimum. In such cases, a single estimate at the fee minimum is added. Two new tests have been added to validate this functionality.

* [`src/lib/DataProviderManager.ts`](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4R62-R66): Added a condition to check if the length of `feeEstimates` is zero. If it is, a single estimate at the fee minimum is added to `feeEstimates`.
  
Testing:

* [`test/DataProviderManager-minfee.test.ts`](diffhunk://#diff-1bdd07d0ebcfe3952cb1b0a8807f0d849db3f91b9225afdd77ec9247d460dd42R1-R73): Added two new tests. The first test checks that estimates below the fee minimum are excluded. The second test ensures that if no valid estimates are available, a single estimate at the fee minimum is returned.