### PR TITLE
Clean up log level usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Here are the available configuration options:
 | `settings.feeMultiplier`  | The multiplier to apply to the fee estimates                                                              | `1`                     | `FEE_MULTIPLIER`     |
 | `settings.feeMinimum`     | The minimum fee (sat/vB) to use for fee estimates if we could not determine from a configured data source | `2`                     | `FEE_MINIMUM`        |
 | `settings.maxHeightDelta` | The maximum acceptable difference between the block heights of the most current fee estimates.            | `3`                     | `MAX_HEIGHT_DELTA`   |
-| `cache.stdTTL`            | The standard time to live in seconds for every generated cache element                                    | `15`                    | `CACHE_STD_TTL`       |
+| `cache.stdTTL`            | The standard time to live in seconds for every generated cache element                                    | `15`                    | `CACHE_STD_TTL`      |
 | `cache.checkperiod`       | The period in seconds, used for the automatic delete check interval                                       | `20`                    | `CACHE_CHECKPERIOD`  |
 
 ### Mempool settings

--- a/src/lib/DataProviderManager.ts
+++ b/src/lib/DataProviderManager.ts
@@ -104,9 +104,9 @@ export class DataProviderManager {
             feeEstimates,
           } as DataPoint;
         } catch (error) {
-          console.error(
-            `Error fetching data from provider ${p.constructor.name}: ${error}`,
-          );
+          log.error({
+            message: `Error fetching data from provider ${p.constructor.name}: ${error}`,
+          });
           return null;
         }
       }),
@@ -161,8 +161,8 @@ export class DataProviderManager {
         dataPoints[0].blockHeight - dp.blockHeight <= this.maxHeightDelta;
 
       if (!isRelevant) {
-        console.warn({
-          msg: `Data point from block ${dp.blockHeight} was filtered out due to relevancy threshold.`,
+        log.warn({
+          message: `Data point from block ${dp.blockHeight} was filtered out due to relevancy threshold.`,
         });
       }
 
@@ -181,7 +181,7 @@ export class DataProviderManager {
       Object.entries(feeEstimates).filter(([blockTarget, estimate]) => {
         if (estimate < this.feeMinimum) {
           log.warn({
-            msg: `Fee estimate for target ${blockTarget} was below the minimum of ${this.feeMinimum}.`,
+            message: `Fee estimate for target ${blockTarget} was below the minimum of ${this.feeMinimum}.`,
           });
           return false;
         }
@@ -206,7 +206,10 @@ export class DataProviderManager {
       const keys = Object.keys(estimates)
         .map(Number)
         .sort((a, b) => a - b);
-      log.debug({ msg: `Estimates for dataPoint ${providerName}`, estimates });
+      log.debug({
+        message: `Estimates for dataPoint ${providerName}`,
+        estimates,
+      });
 
       keys.forEach((key) => {
         // Only add the estimate if it has a higher confirmation target and a lower fee.
@@ -216,14 +219,14 @@ export class DataProviderManager {
             estimates[key] < Math.min(...Object.values(mergedEstimates)))
         ) {
           log.debug({
-            msg: `Adding estimate from ${providerName} with target ${key} and fee ${estimates[key]} to mergedEstimates`,
+            message: `Adding estimate from ${providerName} with target ${key} and fee ${estimates[key]} to mergedEstimates`,
           });
           mergedEstimates[key] = estimates[key];
         }
       });
     }
 
-    log.debug({ msg: "Final mergedEstimates:", mergedEstimates });
+    log.debug({ message: "Final mergedEstimates:", mergedEstimates });
     return mergedEstimates;
   }
 }

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -63,7 +63,7 @@ export async function fetchData<T>(
       : response.text());
     return data as T;
   } catch (error) {
-    log.error({ msg: `Error fetching data from "${url}":`, error });
+    log.warn({ message: `Error fetching data from "${url}":`, error });
     throw error;
   }
 }

--- a/src/providers/bitcoind.ts
+++ b/src/providers/bitcoind.ts
@@ -44,7 +44,7 @@ export class BitcoindProvider implements Provider {
     const getBlockCount = promisify(this.rpc.getBlockCount.bind(this.rpc));
 
     const response = await getBlockCount();
-    log.trace({ msg: "getBlockCount", response: response.result });
+    log.trace({ message: "getBlockCount", response: response.result });
 
     return response.result;
   }
@@ -60,7 +60,7 @@ export class BitcoindProvider implements Provider {
     );
 
     const response = await getBestBlockHash();
-    log.trace({ msg: "getBestBlockHash", response: response.result });
+    log.trace({ message: "getBestBlockHash", response: response.result });
 
     return response.result;
   }
@@ -76,7 +76,7 @@ export class BitcoindProvider implements Provider {
     );
 
     const response = await estimateSmartFee(target, this.mode);
-    log.trace({ msg: "estimateSmartFee", response: response.result });
+    log.trace({ message: "estimateSmartFee", response: response.result });
 
     return response.result?.feerate;
   }
@@ -116,14 +116,14 @@ export class BitcoindProvider implements Provider {
       } catch (error) {
         errorCount++;
         log.warn({
-          msg: `Error getting fee estimate for target ${target}:`,
+          message: `Error getting fee estimate for target ${target}:`,
           errors: responses[i].result?.errors.join(", "),
         });
       }
     });
 
     if (errorCount === this.targets.length) {
-      log.error({ msg: "Error getting fee estimates" });
+      log.error({ message: "Error getting fee estimates" });
       throw new Error("Error getting fee estimates");
     }
 

--- a/src/providers/esplora.ts
+++ b/src/providers/esplora.ts
@@ -121,7 +121,7 @@ export class EsploraProvider implements Provider {
         feeEstimates,
       };
     } catch (error) {
-      log.error({ msg: "Error fetching all data from Esplora:", error });
+      log.error({ message: "Error fetching all data from Esplora:", error });
       throw error;
     }
   }

--- a/src/providers/mempool.ts
+++ b/src/providers/mempool.ts
@@ -122,7 +122,7 @@ export class MempoolProvider implements Provider {
         feeEstimates,
       };
     } catch (error) {
-      log.error({ msg: "Error fetching all data from Mempool:", error });
+      log.error({ message: "Error fetching all data from Mempool:", error });
       throw error;
     }
   }

--- a/src/server.tsx
+++ b/src/server.tsx
@@ -42,7 +42,7 @@ const CACHE_CHECKPERIOD = config.get<number>("cache.checkperiod");
 const log = logger(LOGLEVEL, "server");
 
 const middlewareLogger = (message: string, ...rest: string[]) => {
-  log.info({ msg: message, ...rest });
+  log.info({ message, ...rest });
 };
 
 // Log the configuration values.
@@ -95,8 +95,10 @@ ESPLORA_FALLBACK_BASE_URL &&
 
 // Initialize the Express app.
 const app = new Hono();
-log.info({ msg: `Fee Estimates available at ${BASE_URL}/v1/fee-estimates` });
-log.info({ msg: `Website available at ${BASE_URL}` });
+log.info({
+  message: `Fee Estimates available at ${BASE_URL}/v1/fee-estimates`,
+});
+log.info({ message: `Website available at ${BASE_URL}` });
 
 // Add a health/ready endpoint.
 app.get("/health/ready", async (c) => {


### PR DESCRIPTION
This pull request includes several changes to the logging statements across multiple files to standardize the log message format. The primary change involves replacing the `msg` key with `message` in the log objects.

### Standardization of log message format:

* [`src/lib/DataProviderManager.ts`](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L107-R109): Updated log statements to use `message` instead of `msg` for consistency. [[1]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L107-R109) [[2]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L164-R165) [[3]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L184-R184) [[4]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L209-R212) [[5]](diffhunk://#diff-1ee6a76ca32ff1d0e074612a01fb67b57a16debff45a735b4c15a7f1649240d4L219-R229)
* [`src/lib/util.ts`](diffhunk://#diff-6f611215e3d2978b5127e7c36198526b54c97440b27b9fb25742c9a7ebfa0d0bL66-R66): Changed the log level from `error` to `warn` and updated the log message format.
* [`src/providers/bitcoind.ts`](diffhunk://#diff-d3ac7de24ab679d79867e74090b8c3ea16f65786d8d3605bcc74402d31f48038L47-R47): Standardized log messages by replacing `msg` with `message`. [[1]](diffhunk://#diff-d3ac7de24ab679d79867e74090b8c3ea16f65786d8d3605bcc74402d31f48038L47-R47) [[2]](diffhunk://#diff-d3ac7de24ab679d79867e74090b8c3ea16f65786d8d3605bcc74402d31f48038L63-R63) [[3]](diffhunk://#diff-d3ac7de24ab679d79867e74090b8c3ea16f65786d8d3605bcc74402d31f48038L79-R79) [[4]](diffhunk://#diff-d3ac7de24ab679d79867e74090b8c3ea16f65786d8d3605bcc74402d31f48038L119-R126)
* [`src/providers/esplora.ts`](diffhunk://#diff-a2bc951c0d20eca10a6d0818f85fe3d4ae3b63e51fbba3a195148553470fcf6bL124-R124): Updated error log message format to use `message` instead of `msg`.
* [`src/providers/mempool.ts`](diffhunk://#diff-1fd5ab7ccc4c8b3fc8bd68e64c8437bb611567aa9f0842463420da0529420539L125-R125): Updated error log message format to use `message` instead of `msg`.
* [`src/server.tsx`](diffhunk://#diff-6753353f379b5a26bc9c1219ea6030e27ff3ab93d2f13576f053a426bbe8c05fL45-R45): Standardized log messages by replacing `msg` with `message`. [[1]](diffhunk://#diff-6753353f379b5a26bc9c1219ea6030e27ff3ab93d2f13576f053a426bbe8c05fL45-R45) [[2]](diffhunk://#diff-6753353f379b5a26bc9c1219ea6030e27ff3ab93d2f13576f053a426bbe8c05fL98-R101)