### PR TITLE
Add min_relay_feerate to fee estimator response

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -2,6 +2,7 @@ interface Provider {
   getBlockHeight(): Promise<number>;
   getBlockHash(): Promise<string>;
   getFeeEstimates(): Promise<FeeByBlockTarget>;
+  getMinRelayFeeRate(): Promise<number>;
   getAllData(): Promise<ProviderData>;
 }
 
@@ -10,6 +11,7 @@ type DataPoint = {
   blockHeight: number;
   blockHash: string;
   feeEstimates: FeeByBlockTarget;
+  minRelayFeeRate: number;
 };
 
 // CacheConfig represents the configuration for the cache.
@@ -65,10 +67,19 @@ interface BestBlockHashResponse {
   result: string;
 }
 
+interface MempoolInfoResponse {
+  result: MempoolInfo;
+}
+
+interface MempoolInfo {
+  mempoolminfee: number;
+}
+
 type ProviderData = {
   blockHeight: number;
   blockHash: string;
   feeEstimates: FeeByBlockTarget;
+  minRelayFeeRate: number;
 };
 
 // Estimates represents the current block hash and fee by block target.
@@ -76,6 +87,7 @@ type Estimates = {
   current_block_hash: string | null; // current block hash
   current_block_height: number | null; // current block height
   fee_by_block_target: FeeByBlockTarget; // fee by block target (in sat/kb)
+  min_relay_feerate: number | null; // minimum relay fee rate (in sat/kb)
 };
 
 // SiteData represents the data of a site.

--- a/src/providers/bitcoind.ts
+++ b/src/providers/bitcoind.ts
@@ -145,8 +145,8 @@ export class BitcoindProvider implements Provider {
 
     const feeRate = response.result?.mempoolminfee;
     if (!feeRate) {
-      log.error({ message: "Error getting mempool min fee" });
-      throw new Error("Error getting mempool min fee");
+      log.error({ message: "Error getting mempool min fee, mempoolminfee not found" });
+      throw new Error("Error getting mempool min fee, mempoolminfee not found");
     }
 
     // Convert the returned value to sats/vB, as it's currently returned in BTC/kB.

--- a/src/providers/esplora.ts
+++ b/src/providers/esplora.ts
@@ -103,22 +103,42 @@ export class EsploraProvider implements Provider {
   }
 
   /**
-   * Fetches all data (block height, block hash, and fee estimates) from the Esplora API.
+   * Fetches min fee rate from the Esplora API.
+   *
+   * @returns A promise that resolves to the fetched min fee rate.
+   */
+  async getMinRelayFeeRate(): Promise<number> {
+    const data = await fetchData<EsploraFeeEstimates>(
+      `${this.url}/api/fee-estimates`,
+      "json",
+      this.timeout,
+    );
+
+    const feeRates = Object.values(data);
+    // Currently the Esplora API does not provide a minimum relay fee rate
+    // so we return the minimum fee rate from the fee estimates
+    return Math.min(...feeRates);
+  }
+
+  /**
+   * Fetches all data (block height, block hash, fee estimates and minFeeRelayFeeRate) from the Esplora API.
    *
    * @returns A promise that resolves to an object of all data.
    */
   public async getAllData(): Promise<ProviderData> {
     try {
-      const [blockHeight, blockHash, feeEstimates] = await Promise.all([
+      const [blockHeight, blockHash, feeEstimates, minRelayFeeRate] = await Promise.all([
         this.getBlockHeight(),
         this.getBlockHash(),
         this.getFeeEstimates(),
+        this.getMinRelayFeeRate(),
       ]);
 
       return {
         blockHeight,
         blockHash,
         feeEstimates,
+        minRelayFeeRate,
       };
     } catch (error) {
       log.error({ message: "Error fetching all data from Esplora:", error });

--- a/src/providers/mempool.ts
+++ b/src/providers/mempool.ts
@@ -104,22 +104,43 @@ export class MempoolProvider implements Provider {
   }
 
   /**
+   * Fetches min fee rate from the Mempool API.
+   *
+   * @returns A promise that resolves to the fetched min fee rate.
+   */
+  async getMinRelayFeeRate(): Promise<number> {
+    const data = await fetchData<MempoolFeeEstimates>(
+      `${this.url}/api/v1/fees/recommended`,
+      "json",
+      this.timeout,
+    );
+
+    if (!data.minimumFee) {
+      throw new Error("Invalid fee data");
+    }
+
+    return data.minimumFee;
+  }
+
+  /**
    * Fetches all data (block height, block hash, and fee estimates) from the Mempool API.
    *
    * @returns A promise that resolves to an object of all data.
    */
   public async getAllData(): Promise<ProviderData> {
     try {
-      const [blockHeight, blockHash, feeEstimates] = await Promise.all([
+      const [blockHeight, blockHash, feeEstimates, minRelayFeeRate] = await Promise.all([
         this.getBlockHeight(),
         this.getBlockHash(),
         this.getFeeEstimates(),
+        this.getMinRelayFeeRate(),
       ]);
 
       return {
         blockHeight,
         blockHash,
         feeEstimates,
+        minRelayFeeRate,
       };
     } catch (error) {
       log.error({ message: "Error fetching all data from Mempool:", error });

--- a/test/DataProviderManager-merge.test.ts
+++ b/test/DataProviderManager-merge.test.ts
@@ -4,6 +4,7 @@ import { DataProviderManager } from "../src/lib/DataProviderManager";
 class MockProvider0 implements Provider {
   getBlockHeight = () => Promise.resolve(1001);
   getBlockHash = () => Promise.resolve("hash1001");
+  getMinRelayFeeRate = () => Promise.resolve(1);
   getFeeEstimates = () =>
     Promise.resolve({
       "1": 1,
@@ -19,12 +20,14 @@ class MockProvider0 implements Provider {
         "2": 1,
         "3": 1,
       },
+      minRelayFeeRate: 1,
     });
 }
 
 class MockProvider1 implements Provider {
   getBlockHeight = () => Promise.resolve(998);
   getBlockHash = () => Promise.resolve("hash998");
+  getMinRelayFeeRate = () => Promise.resolve(1);
   getFeeEstimates = () =>
     Promise.resolve({
       "1": 20,
@@ -38,12 +41,14 @@ class MockProvider1 implements Provider {
         "1": 20,
         "10": 1,
       },
+      minRelayFeeRate: 1,
     });
 }
 
 class MockProvider2 implements Provider {
   getBlockHeight = () => Promise.resolve(1000);
   getBlockHash = () => Promise.resolve("hash1000");
+  getMinRelayFeeRate = () => Promise.resolve(1);
   getFeeEstimates = () =>
     Promise.resolve({
       "1": 30,
@@ -57,12 +62,14 @@ class MockProvider2 implements Provider {
         "1": 30,
         "2": 20,
       },
+      minRelayFeeRate: 1,
     });
 }
 
 class MockProvider3 implements Provider {
   getBlockHeight = () => Promise.resolve(999);
   getBlockHash = () => Promise.resolve("hash999");
+  getMinRelayFeeRate = () => Promise.resolve(1);
   getFeeEstimates = () =>
     Promise.resolve({
       "1": 25,
@@ -88,6 +95,7 @@ class MockProvider3 implements Provider {
         "8": 3.564999999999998,
         "9": 3.564999999999998,
       },
+      minRelayFeeRate: 1,
     });
 }
 
@@ -115,4 +123,5 @@ test("should merge fee estimates from multiple providers correctly", async () =>
     "3": 10000,
     "5": 7130,
   });
+  expect(mergedData.min_relay_feerate).toEqual(2000);
 });

--- a/test/DataProviderManager-sort.test.ts
+++ b/test/DataProviderManager-sort.test.ts
@@ -7,11 +7,13 @@ class MockProvider1 implements Provider {
   getBlockHeight = () => Promise.resolve(998);
   getBlockHash = () => Promise.resolve("hash1");
   getFeeEstimates = () => Promise.resolve({});
+  getMinRelayFeeRate = () => Promise.resolve(0);
   getAllData = () =>
     Promise.resolve({
       blockHeight: 998,
       blockHash: "hash1",
       feeEstimates: {},
+      minRelayFeeRate: 0,
     });
 }
 
@@ -19,11 +21,13 @@ class MockProvider2 implements Provider {
   getBlockHeight = () => Promise.resolve(1000);
   getBlockHash = () => Promise.resolve("hash3");
   getFeeEstimates = () => Promise.resolve({});
+  getMinRelayFeeRate = () => Promise.resolve(0);
   getAllData = () =>
     Promise.resolve({
       blockHeight: 1000,
       blockHash: "hash3",
       feeEstimates: {},
+      minRelayFeeRate: 0,
     });
 }
 
@@ -31,11 +35,13 @@ class MockProvider3 implements Provider {
   getBlockHeight = () => Promise.resolve(999);
   getBlockHash = () => Promise.resolve("hash2");
   getFeeEstimates = () => Promise.resolve({});
+  getMinRelayFeeRate = () => Promise.resolve(0);
   getAllData = () =>
     Promise.resolve({
       blockHeight: 999,
       blockHash: "hash2",
       feeEstimates: {},
+      minRelayFeeRate: 0,
     });
 }
 

--- a/test/bitcoind.test.ts
+++ b/test/bitcoind.test.ts
@@ -30,6 +30,10 @@ mockRpcClient.estimateSmartFee = (
   cb: (error: any, result: EstimateSmartFeeBatchResponse) => void,
 ) => cb(null, { result: { feerate: 1000 } });
 
+mockRpcClient.getMempoolInfo = (
+  cb: (error: any, result: MempoolInfoResponse) => void,
+) => cb(null, { result: { mempoolminfee: 0.00001234 } });
+
 const provider = new BitcoindProvider(
   "http://localhost:18445",
   "user",
@@ -56,6 +60,11 @@ test("getBlockHash", async () => {
 test("getFeeEstimate", async () => {
   const result = await provider.getFeeEstimate(2);
   expect(result).toEqual(1000);
+});
+
+test("getMinRelayFeeRate", async () => {
+  const result = await provider.getMinRelayFeeRate();
+  expect(result).toEqual(1.234);
 });
 
 // test("getFeeEstimates", async () => {

--- a/test/esplora.test.ts
+++ b/test/esplora.test.ts
@@ -31,8 +31,13 @@ test("getBlockHash should return a 64-character hexadecimal string representing 
   expect(blockHash).toMatch(/^[a-fA-F0-9]{64}$/);
 });
 
+test("getMinRelayFeeRate should return a number representing the minimum fee rate", async () => {
+  const minRelayFeeRate = await esploraProvider.getMinRelayFeeRate();
+  expect(typeof minRelayFeeRate).toBe("number");
+});
+
 test("getAllData should return an object containing the block height, block hash, and fee estimates", async () => {
-  const { blockHeight, blockHash, feeEstimates } =
+  const { blockHeight, blockHash, feeEstimates, minRelayFeeRate } =
     await esploraProvider.getAllData();
 
   expect(typeof blockHeight).toBe("number");
@@ -43,4 +48,5 @@ test("getAllData should return an object containing the block height, block hash
   expect(typeof feeEstimates["1"]).toBe("number");
   expect(typeof feeEstimates["3"]).toBe("number");
   expect(typeof feeEstimates["6"]).toBe("number");
+  expect(typeof minRelayFeeRate).toBe("number");
 });

--- a/test/mempool.test.ts
+++ b/test/mempool.test.ts
@@ -31,8 +31,13 @@ test("getBlockHash should return a 64-character hexadecimal string representing 
   expect(blockHash).toMatch(/^[a-fA-F0-9]{64}$/);
 });
 
+test("getMinRelayFeeRate should return a number representing the minimum fee rate", async () => {
+  const minRelayFeeRate = await mempoolProvider.getMinRelayFeeRate();
+  expect(typeof minRelayFeeRate).toBe("number");
+});
+
 test("getAllData should return an object containing the block height, block hash, and fee estimates", async () => {
-  const { blockHeight, blockHash, feeEstimates } =
+  const { blockHeight, blockHash, feeEstimates, minRelayFeeRate } =
     await mempoolProvider.getAllData();
 
   expect(typeof blockHeight).toBe("number");
@@ -43,4 +48,5 @@ test("getAllData should return an object containing the block height, block hash
   expect(typeof feeEstimates["1"]).toBe("number");
   expect(typeof feeEstimates["3"]).toBe("number");
   expect(typeof feeEstimates["6"]).toBe("number");
+  expect(typeof minRelayFeeRate).toBe("number");
 });


### PR DESCRIPTION
## Description:

Ensure the fee estimator response returns a new property called `min_relay_feerate`

We try to fetch some kind of minimum fee rate value from each provider, and then select the highest of all collected values. This is to ensure we prefer a too high vs a too low minimum fee rate to be returned.

The logic is also updated so that all fee estimations are filtered based on this min_relay_feerate value as well.

### TODO:
- [x] Fix broken tests

## Motivation and Context:

LND v0.18.3 and forwards expect this new property to exist. See here: https://github.com/lightningnetwork/lnd/blob/0-18-4-branch/docs/release-notes/release-notes-0.18.3.md#functional-updates

Closes #63

## Types of changes:

Enhancement