### PR TITLE
Fix casing issue for bitcoind getMemPoolInfo RPC

### DIFF
--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -67,11 +67,11 @@ interface BestBlockHashResponse {
   result: string;
 }
 
-interface MempoolInfoResponse {
-  result: MempoolInfo;
+interface MemPoolInfoResponse {
+  result: MemPoolInfo;
 }
 
-interface MempoolInfo {
+interface MemPoolInfo {
   mempoolminfee: number;
 }
 

--- a/src/providers/bitcoind.ts
+++ b/src/providers/bitcoind.ts
@@ -136,12 +136,12 @@ export class BitcoindProvider implements Provider {
    * @returns A promise that resolves to the fetched min fee rate.
    */
   async getMinRelayFeeRate(): Promise<number> {
-    const getMempoolInfo = promisify(
-      this.rpc.getMempoolInfo.bind(this.rpc),
+    const getMemPoolInfo = promisify(
+      this.rpc.getMemPoolInfo.bind(this.rpc),
     );
 
-    const response = await getMempoolInfo();
-    log.trace({ message: "getMempoolInfo", response: response.result });
+    const response = await getMemPoolInfo();
+    log.trace({ message: "getMemPoolInfo", response: response.result });
 
     const feeRate = response.result?.mempoolminfee;
     if (!feeRate) {

--- a/test/bitcoind.test.ts
+++ b/test/bitcoind.test.ts
@@ -30,8 +30,8 @@ mockRpcClient.estimateSmartFee = (
   cb: (error: any, result: EstimateSmartFeeBatchResponse) => void,
 ) => cb(null, { result: { feerate: 1000 } });
 
-mockRpcClient.getMempoolInfo = (
-  cb: (error: any, result: MempoolInfoResponse) => void,
+mockRpcClient.getMemPoolInfo = (
+  cb: (error: any, result: MemPoolInfoResponse) => void,
 ) => cb(null, { result: { mempoolminfee: 0.00001234 } });
 
 const provider = new BitcoindProvider(


### PR DESCRIPTION
Followup to https://github.com/LN-Zap/bitcoin-blended-fee-estimator/pull/64

The `getMemPoolInfo` RPC call I added in that PR did not have the correct casing, which makes this call to bitcoind fail.

This PR fixes the casing issue.