### PR TITLE
feat(ci): dual-push release to Docker Hub + GAR via build-push-gar

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,29 +6,18 @@ on:
 
 jobs:
   publish:
-    runs-on: "ubuntu-latest"
-
-    env:
-      DOCKERHUB_IMAGE: lnzap/bitcoin-blended-fee-estimator
-
-    steps:
-      - name: Checkout Code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # pin@v4
-
-      - name: Set version
-        run: echo "VERSION=$(echo ${{ github.ref }} | awk -F 'v' '{print $2}')" >> $GITHUB_ENV
-
-      - name: Dockerhub login
-        run: "docker login --username ${{ secrets.DOCKER_USERNAME }} --password ${{ secrets.DOCKER_PASSWORD }}"
-
-      - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # pin@v3
-      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # pin@v3
-      - uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # pin@v5
-        with:
-          push: true
-          tags: |
-            ${{ env.DOCKERHUB_IMAGE }}:latest
-            ${{ env.DOCKERHUB_IMAGE }}:${{ env.VERSION }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+    # Dual-publish to Docker Hub (public) and GAR (internal) via the shared reusable
+    # pipeline. GAR push is keyless WIF/OIDC, which works from this public repo where
+    # org secrets are unavailable — replacing the old flip-private-per-release workaround.
+    # See LN-Zap/zap-infrastructure#1402.
+    permissions:
+      id-token: write # WIF / OIDC for GAR
+      contents: read
+    uses: LN-Zap/zap-github-actions/.github/workflows/build-push-gar.yml@a7bebd44777efa7ae1fbaabcf232ed078067256d
+    with:
+      image-name: bitcoin-blended-fee-estimator
+      dockerhub-image: lnzap/bitcoin-blended-fee-estimator
+      platforms: linux/amd64,linux/arm64
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
Closes LN-Zap/zap-infrastructure#1402.

Switches the release workflow to the shared `build-push-gar.yml` reusable pipeline, which **dual-publishes to Docker Hub (public) and GAR (internal)** on each published release.

### Why
GAR push from this repo broke when it was open-sourced — org secrets aren't available to public repos, so releases relied on temporarily flipping the repo to private (noisy SOC alerts, manual toil). The reusable pipeline pushes to GAR via **keyless WIF/OIDC**, which works fine from a public repo, eliminating both the org-secret dependency and the workaround.

### Behaviour preserved
- Docker Hub `lnzap/bitcoin-blended-fee-estimator` still published with `:latest` + `:<version>` (version derived from the `vX.Y.Z` tag, `v` stripped — same as before).
- Multi-arch `linux/amd64,linux/arm64`, GHA layer cache.
- Plus GAR: `us-east1-docker.pkg.dev/zap-strike-infrastructure/zap-container-registry/bitcoin-blended-fee-estimator`.

The pipeline also adds a staging-tag → (smoke) → promote flow so mutable tags only ever point at a verified digest.

### Requires first (merge order)
- LN-Zap/zap-terraform#7257 — WIF binding for the GAR writer SA (must be applied)
- LN-Zap/zap-github-actions#80 — image-ownership allowlist entry

Without both in place a release will fail at WIF auth / ownership assertion. This PR is safe to merge independently — it only executes on the next published release.

> Note: `DOCKER_USERNAME` / `DOCKER_PASSWORD` are passed through unchanged (already in use by the previous workflow). Internal deployments continue to pull from Docker Hub today; switching the helm `apps/fee-estimator` values to the GAR path is a separate optional follow-up.
